### PR TITLE
Memory fix for pak export

### DIFF
--- a/UAssetGUI/FileContainerForm.cs
+++ b/UAssetGUI/FileContainerForm.cs
@@ -1290,43 +1290,48 @@ namespace UAssetGUI
                             using (FileStream stream = new FileStream(ParentForm.CurrentContainerPath, FileMode.Open))
                             {
                                 var reader = new PakBuilder().Reader(stream);
+                                string basePath = FullPath.Substring(Prefix?.Length ?? 0);
 
-                                byte[] res = reader.Get(stream, FullPath.Substring(Prefix?.Length ?? 0));
-                                if (res != null)
-                                {
-                                    UAGUtils.DeleteFileQuick(outputPath1);
-                                    File.WriteAllBytes(outputPath1, res);
-                                }
-                                else
-                                {
-                                    return null;
-                                }
+                                byte[] res = reader.Get(stream, basePath);
+                                if (res == null) return null;
+                                UAGUtils.DeleteFileQuick(outputPath1);
+                                File.WriteAllBytes(outputPath1, res);
+                                res = null;
 
-                                res = reader.Get(stream, Path.ChangeExtension(FullPath.Substring(Prefix?.Length ?? 0), ".uexp"));
+                                res = reader.Get(stream, Path.ChangeExtension(basePath, ".uexp"));
                                 UAGUtils.DeleteFileQuick(outputPath2);
-                                if (res != null) File.WriteAllBytes(outputPath2, res);
+                                if (res != null) { File.WriteAllBytes(outputPath2, res); res = null; }
 
-                                res = reader.Get(stream, Path.ChangeExtension(FullPath.Substring(Prefix?.Length ?? 0), ".ubulk"));
+                                res = reader.Get(stream, Path.ChangeExtension(basePath, ".ubulk"));
                                 UAGUtils.DeleteFileQuick(outputPath3);
-                                if (res != null) File.WriteAllBytes(outputPath3, res);
+                                if (res != null) { File.WriteAllBytes(outputPath3, res); res = null; }
                             }
                         }
                         else
                         {
-                            byte[] res = reader2.Get(stream2, FullPath.Substring(Prefix?.Length ?? 0));
-                            if (res != null)
-                            {
-                                File.WriteAllBytes(outputPath1, res);
-                            }
-                            else
-                            {
+                            string basePath = FullPath.Substring(Prefix?.Length ?? 0);
+                            byte[] res = reader2.Get(stream2, basePath);
+
+                            if (res == null) 
                                 return null;
+
+                            UAGUtils.DeleteFileQuick(outputPath1);
+                            File.WriteAllBytes(outputPath1, res);
+                            res = null;
+
+                            res = reader2.Get(stream2, Path.ChangeExtension(basePath, ".uexp"));
+                            UAGUtils.DeleteFileQuick(outputPath2);
+                            if (res != null) {
+                                File.WriteAllBytes(outputPath2, res); 
+                                res = null; 
                             }
 
-                            res = reader2.Get(stream2, Path.ChangeExtension(FullPath.Substring(Prefix?.Length ?? 0), ".uexp"));
-                            if (res != null) File.WriteAllBytes(outputPath2, res);
-                            res = reader2.Get(stream2, Path.ChangeExtension(FullPath.Substring(Prefix?.Length ?? 0), ".ubulk"));
-                            if (res != null) File.WriteAllBytes(outputPath3, res);
+                            res = reader2.Get(stream2, Path.ChangeExtension(basePath, ".ubulk"));
+                            UAGUtils.DeleteFileQuick(outputPath3);
+                            if (res != null) { 
+                                File.WriteAllBytes(outputPath3, res); 
+                                res = null; 
+                            }
                         }
                     }
                     break;

--- a/UAssetGUI/FileContainerForm.cs
+++ b/UAssetGUI/FileContainerForm.cs
@@ -1099,7 +1099,7 @@ namespace UAssetGUI
                 tsmItem = new ToolStripMenuItem(UAGConfig.GetString("FileContainerForm.ContextMenu.Extract"));
                 tsmItem.Click += (sender, args) =>
                 {
-                    string outPath = UAGConfig.ExtractFile(Pointer, item.ParentForm.InteropType);
+                    string outPath = UAGConfig.ExtractPakNode(Pointer, item.ParentForm.InteropType);
                     if (outPath == null) return;
                     if ((Path.GetExtension(outPath)?.Length ?? 0) > 0) outPath = Path.GetDirectoryName(outPath);
                     UAGUtils.OpenDirectory(outPath);

--- a/UAssetGUI/UAGConfig.cs
+++ b/UAssetGUI/UAGConfig.cs
@@ -203,6 +203,60 @@ namespace UAssetGUI
             return item.SaveFileToTemp(interopType, ExtractedFolder, stream2, reader2);
         }
 
+        public static string ExtractPakNode(DirectoryTreeItem item, InteropType interopType)
+        {
+            var finalPath = Path.Combine(ExtractedFolder, item.FullPath.Replace('/', Path.DirectorySeparatorChar));
+
+            List<DirectoryTreeItem> ItemsToExport = GetNodeItemList(item);
+
+            if (ItemsToExport.Count > 0)
+            {
+
+                using (FileStream stream = new FileStream(item.ParentForm.CurrentContainerPath, FileMode.Open))
+                {
+                    using (var reader = new PakBuilder().Reader(stream))
+                    {
+                        foreach (var child in ItemsToExport)
+                            child.SaveFileToTemp(interopType, ExtractedFolder, stream, reader);
+                    }
+                }
+            }
+
+            return finalPath;
+        }
+
+        public static List<DirectoryTreeItem> GetNodeItemList(DirectoryTreeItem rootNode)
+        {
+            var ExportFiles = new List<DirectoryTreeItem>();
+            var FolderStack = new Stack<DirectoryTreeItem>();
+
+            if (rootNode.IsFile)
+            {
+                ExportFiles.Add(rootNode);
+                return ExportFiles;
+            }
+
+            FolderStack.Push(rootNode);
+
+            while (FolderStack.Count > 0)
+            {
+                var iterItem = FolderStack.Pop();
+
+                foreach (var child in iterItem.Children.Values)
+                {
+                    if (child.IsFile)
+                    {
+                        ExportFiles.Add(child);
+                    } 
+                    else
+                    {
+                        FolderStack.Push(child);
+                    }
+                }
+            }
+
+            return ExportFiles;
+        }
         public static bool TryGetMappings(string name, out Usmap mappings)
         {
             if (AllMappings.TryGetValue(name, out string value))


### PR DESCRIPTION
# Pull Request

## Description
Commit 6985e51
Added var for basePath for cleaner code, and res=null; 
Since what the reader is reading can be large, it gets added to the large object heap, reseting the value to null flags it for GC as recouperable space.

Commit 5795288
When trying to extract Deadside's main .pak, UAssetGUI would consume every bit of memory it can and barely manage around 99% and eventually a larger export would kill the process and the debugger with it.
This linear approach which (most importantly) reuses the same stream and reader prevents memory from building up.

Additionally, in the prior game version which did extract successfully the process lasted for about 10 minutes. With this approach the export duration is 13 secionds and there's a minor memory bump which goes away as soon as the process completes.

Important note: I fully understand that my discreet experience with Deadside is far from covering any other UE 4 or 5 game. I'm PR-ing this in best faith, and in case it seems implausable, I still advise the linear stack approach as it has several benefits which outclass any downsides: a) list position can be referenced in a progress bar if it's implemented, b) easier to debug as there's a separation of concerns between assessing what needs to be exported, and actual export process.

Key takeaway is, even if a single reader/stream can't be reused (in case there's multiple paks and each exported object needs to point to it's pak for example, I don't know if this is possible even, but then again, I don't know what are possible permutations either), they should be maintained separately instead of spawning new ones for every file being exported. This causes huge memory and time overhead.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Open UAssetGUI, 
Click File > Open Containers..., 
select a production ready game pak (I used game Deadside which is based on UE4.27)
Expand to Content > Blueprints, 
Right click Blueprints > Export
*Monitor how long it takes and how much memory it consumes
